### PR TITLE
docs: npm discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "aleph-js",
   "version": "0.4.3",
   "description": "Javascript client library for the Aleph network",
+  "homepage": "https://aleph-im.github.io/aleph-js",
+  "repository": "aleph-im/aleph-js.git",
   "main": "dist/aleph-js.cjs.js",
   "browser": "dist/aleph-js.umd.js",
   "module": "dist/aleph-js.esm.js",


### PR DESCRIPTION
These metadata makes these links appear on the npm package page which makes it easier to understand what its all about in addition to the README